### PR TITLE
Iron out some kinks in v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ import { Client } from "pg"
   })
   await client.connect()
   try {
-    await overwriteDatabaseMd5(client, "path/to/your/migration-file.sql")
+    await overwriteDatabaseMd5(client, "20260122153125.sql")
   } finally {
     await client.end()
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcduez/pg-migrate",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "type": "commonjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,6 +86,7 @@ yargs(hideBin(process.argv))
     migrationTable: string
     pgDumpPath: string
     schemaFile: string
+    throwOnChangedSchema: boolean
     timeoutSeconds?: number
     host?: string
     port?: number
@@ -118,6 +119,12 @@ yargs(hideBin(process.argv))
         default: "schema.sql",
         describe:
           "File that the database schema will be written to after applying migrations (set to empty string to skip writing schema)",
+      },
+      "throw-on-changed-schema": {
+        alias: "c",
+        default: false,
+        describe:
+          "If set, pg-migrate will throw an error if it detects that the database schema was changed by applying migrations",
       },
       "timeout-seconds": {
         alias: "T",
@@ -159,6 +166,7 @@ yargs(hideBin(process.argv))
       migrationTable,
       pgDumpPath,
       schemaFile,
+      throwOnChangedSchema,
       timeoutSeconds,
       host,
       port,
@@ -184,6 +192,7 @@ yargs(hideBin(process.argv))
           migrationTable,
           pgDumpPath,
           schemaFile,
+          throwOnChangedSchema,
           timeoutSeconds,
         )
       } finally {


### PR DESCRIPTION
- Fix restrict key in pg_dump output to prevent unnecessary diffs.
- Add throwOnChangedSchema option to migrateDatabase function. Designed for use in CI to ensure that migrations have no unexpected consequences.