### PR TITLE
Version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcduez/pg-migrate",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "type": "commonjs",

--- a/src/get-database-dump/get-extensions.ts
+++ b/src/get-database-dump/get-extensions.ts
@@ -1,4 +1,4 @@
-import type { Client } from "pg"
+import { escapeLiteral, type Client } from "pg"
 
 export const getExtensions = async (client: Client) => {
   const { rows } = await client.query<{
@@ -21,7 +21,7 @@ export const getExtensions = async (client: Client) => {
 
   return rows
     .flatMap(({ extension_comment, extension_name, schema_name }) => {
-      const escapedComment = client.escapeLiteral(extension_comment)
+      const escapedComment = escapeLiteral(extension_comment)
       return [
         `CREATE EXTENSION IF NOT EXISTS ${extension_name} WITH SCHEMA ${schema_name};`,
         `COMMENT ON EXTENSION ${extension_name} IS ${escapedComment};`,

--- a/src/get-database-dump/get-tables-and-views.ts
+++ b/src/get-database-dump/get-tables-and-views.ts
@@ -1,4 +1,4 @@
-import type { Client } from "pg"
+import { escapeLiteral, type Client } from "pg"
 
 export const getTablesAndViews = async (client: Client) => {
   const { rows: columnRows } = await client.query<{
@@ -85,7 +85,7 @@ export const getTablesAndViews = async (client: Client) => {
       const columnLine = `${column_name} ${column_type}${defaultClause}${notNullClause}`
 
       const escapedComment = column_comment
-        ? client.escapeLiteral(column_comment)
+        ? escapeLiteral(column_comment)
         : null
       const commentLine = escapedComment
         ? `COMMENT ON COLUMN ${tableWithSchema}.${column_name} IS ${escapedComment};`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,13 +17,16 @@ import {
 vi.mock("pg", () => {
   const Client = vi.fn(
     class {
-      escapeIdentifier = (identifier: string) => `"${identifier}"`
-      escapeLiteral = (literal: string) => `'${literal}'`
       query = vi.fn()
     },
   )
-  return { Client }
+  return {
+    escapeIdentifier: (identifier: string) => `"${identifier}"`,
+    escapeLiteral: (literal: string) => `'${literal}'`,
+    Client,
+  }
 })
+
 vi.mock("child_process")
 type ExecFn = (
   command: string,


### PR DESCRIPTION
- Use global escapeIdentifier and escapeLiteral instead of ones on client - those methods don't exist on the pool client for some reason.