### PR TITLE
Version 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcduez/pg-migrate",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "type": "commonjs",


### PR DESCRIPTION
- Remove comments from pg_dump output.
- Warn on migrations in database but not in files, but don't throw. An attempt to reduce friction when developers have migrations in other branches.