### PR TITLE
Fix sequence MAXVALUE/MINVALUE comparison for bigint columns

### DIFF
--- a/src/dump-schema/get-sequence-statements.ts
+++ b/src/dump-schema/get-sequence-statements.ts
@@ -67,10 +67,10 @@ export const getSequenceStatements = async (client: Client) => {
         `CREATE SEQUENCE ${schema_name}.${name}`,
         `    START WITH ${start_value}`,
         `    INCREMENT BY ${increment_by}`,
-        min_value === start_value
+        String(min_value) === String(start_value)
           ? "    NO MINVALUE"
           : `    MINVALUE ${min_value}`,
-        max_value === MAX_VALUES_BY_TYPE.get(data_type)
+        String(max_value) === MAX_VALUES_BY_TYPE.get(data_type)
           ? "    NO MAXVALUE"
           : `    MAXVALUE ${max_value}`,
         ...(cycle ? ["    CYCLE"] : []),


### PR DESCRIPTION
## Problem

`getSequenceStatements` compares `max_value` from `pg_sequences` against string entries in `MAX_VALUES_BY_TYPE` using strict equality (`===`). Since `pg_sequences.max_value` is a `bigint` column, the node-postgres driver may return it as a `string`, `number`, or `BigInt` depending on version and configuration.

When the type doesn't match, the comparison fails and the dump outputs `MAXVALUE 9223372036854775807` instead of the equivalent `NO MAXVALUE`. This causes noisy diffs in `schema.sql` across developer machines with different `pg` driver behavior.

## Fix

Coerce values with `String()` before comparing, so the output is stable regardless of how the driver represents bigint values.

Same fix applied to the `min_value === start_value` comparison for `NO MINVALUE`.