### PR TITLE
v3.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcduez/pg-migrate",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "type": "commonjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -450,6 +450,11 @@ yargs(hideBin(process.argv))
         describe:
           "Database connection string (or set PGURI or DATABASE_URL env variable)",
       },
+      "migration-table": {
+        alias: "t",
+        default: "migrations",
+        describe: "Database table that tracks previously applied migrations",
+      },
     },
     handler: async ({
       schemaFile,
@@ -459,6 +464,7 @@ yargs(hideBin(process.argv))
       username,
       password,
       connectionString,
+      migrationTable,
     }) => {
       const client = getClient({
         host,
@@ -470,7 +476,7 @@ yargs(hideBin(process.argv))
       })
       await client.connect()
       try {
-        await dumpSchemaToFile(client, schemaFile)
+        await dumpSchemaToFile(client, schemaFile, migrationTable)
       } finally {
         await client.end()
       }

--- a/src/dump-schema/dump-schema.ts
+++ b/src/dump-schema/dump-schema.ts
@@ -6,6 +6,7 @@ import { getExtensionStatements } from "./get-extension-statements.js"
 import { getForeignKeyConstraintStatements } from "./get-foreign-key-constraint-statements.js"
 import { getFunctionStatements } from "./get-function-statements.js"
 import { getIndexStatements } from "./get-index-statements.js"
+import { getInsertMigrationRowStatements } from "./get-insert-migration-row-statements.js"
 import { getSequenceStatements } from "./get-sequence-statements.js"
 import { getTableAndViewStatements } from "./get-table-and-view-statements.js"
 import { getTriggerStatements } from "./get-trigger-statements.js"
@@ -13,7 +14,10 @@ import { getTriggerStatements } from "./get-trigger-statements.js"
 /**
  * Dumps the schema of a PostgreSQL database as a string of SQL statements that can be used to recreate the schema.
  */
-export const dumpSchema = async (client: Client) => {
+export const dumpSchema = async (
+  client: Client,
+  migrationTableName: string,
+) => {
   const createTableAndViewStatements =
     await getCreateTableAndViewStatements(client)
   const hoistedTablesAndViewNames: string[] = []
@@ -40,5 +44,6 @@ export const dumpSchema = async (client: Client) => {
     ...(await getIndexStatements(client)),
     ...(await getTriggerStatements(client)),
     ...(await getForeignKeyConstraintStatements(client)),
+    ...(await getInsertMigrationRowStatements(client, migrationTableName)),
   ].join("\n\n\n")
 }

--- a/src/dump-schema/get-create-table-and-view-statements.ts
+++ b/src/dump-schema/get-create-table-and-view-statements.ts
@@ -78,7 +78,7 @@ export const getCreateTableAndViewStatements = async (client: Client) => {
     and pg_type_is_visible(att.atttypid)  
     and att.attnum > 0
     and not att.attisdropped
-  order by ns.nspname::text, table_cl.relname::text, att.attnum`)
+  order by ns.nspname::text, table_cl.relname::text, att.attname`)
 
   const { rows: viewRows } = await client.query<{
     comment: string | null
@@ -162,7 +162,7 @@ export const getCreateTableAndViewStatements = async (client: Client) => {
     and pg_type_is_visible(att.atttypid)  
     and att.attnum > 0
     and not att.attisdropped
-  order by ns.nspname::text, view_cl.relname::text, att.attnum`)
+  order by ns.nspname::text, view_cl.relname::text, att.attname`)
 
   const viewColumnCommentsByViewName = new Map<string, string[]>(
     viewColumnCommentRows.reduce(

--- a/src/dump-schema/get-domain-and-enum-statements.ts
+++ b/src/dump-schema/get-domain-and-enum-statements.ts
@@ -58,8 +58,8 @@ export const getDomainAndEnumStatements = async (client: Client) => {
 
     -- Select enums
     select
-      ns.nspname 
-      , t.typname
+      ns.nspname as schema_name
+      , t.typname as name
       , 'enum' as row_type
       , e.enumlabel as enum_value
       , e.enumsortorder as enum_sort_order
@@ -80,7 +80,7 @@ export const getDomainAndEnumStatements = async (client: Client) => {
       d.objoid = t.oid
       and d.classoid = 'pg_catalog.pg_type'::regclass
   ) t
-  order by schema_name::text, name::text, enum_sort_order, domain_constraint_name::text`)
+  order by schema_name::text, name::text, enum_value, domain_constraint_name::text`)
 
   return rows
     .reduce<

--- a/src/dump-schema/get-insert-migration-row-statements.ts
+++ b/src/dump-schema/get-insert-migration-row-statements.ts
@@ -1,0 +1,21 @@
+import { Client } from "pg"
+
+export const getInsertMigrationRowStatements = async (
+  client: Client,
+  migrationTableName: string,
+) => {
+  const { rows } = await client.query<{
+    filename: string
+    md5: string
+  }>(`
+    select
+      quote_literal(filename) as filename
+      , quote_literal(md5) as md5
+    from public.${migrationTableName}
+    order by filename`)
+
+  return rows.map(
+    ({ filename, md5 }) =>
+      `INSERT INTO public.${migrationTableName} (filename, md5) values (${filename}, ${md5});`,
+  )
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -473,7 +473,7 @@ describe("migrateDatabase()", () => {
     await migrateDatabase(client)
 
     expect(mockQuery).toHaveBeenCalledTimes(409)
-    expect(mockDumpSchema.mock.calls).toStrictEqual([[client]])
+    expect(mockDumpSchema.mock.calls).toStrictEqual([[client, "migrations"]])
     expect(fs.readFileSync(schemaFilePath, "utf-8")).toBe("new-schema")
   })
 
@@ -961,9 +961,11 @@ describe("dumpSchemaToFile()", () => {
 
     const client = new Client()
 
-    await dumpSchemaToFile(client, schemaFilePath)
+    await dumpSchemaToFile(client, schemaFilePath, "migration_table")
 
-    expect(mockDumpSchema.mock.calls).toStrictEqual([[client]])
+    expect(mockDumpSchema.mock.calls).toStrictEqual([
+      [client, "migration_table"],
+    ])
     expect(fs.readFileSync(schemaFilePath, "utf-8")).toBe("new-schema")
   })
 
@@ -979,7 +981,7 @@ describe("dumpSchemaToFile()", () => {
     const client = new Client()
 
     await expect(
-      dumpSchemaToFile(client, schemaFilePath, true),
+      dumpSchemaToFile(client, schemaFilePath, undefined, true),
     ).rejects.toThrow("Database schema was unexpectedly changed by migrations!")
   })
 
@@ -997,7 +999,7 @@ describe("dumpSchemaToFile()", () => {
     const client = new Client()
 
     await expect(
-      dumpSchemaToFile(client, schemaFilePath, false, {
+      dumpSchemaToFile(client, schemaFilePath, undefined, false, {
         info: mockInfo,
       }),
     ).resolves.not.toThrow()
@@ -1011,7 +1013,7 @@ describe("dumpSchemaToFile()", () => {
 
     const client = new Client()
 
-    await dumpSchemaToFile(client, "", undefined, {
+    await dumpSchemaToFile(client, "", undefined, undefined, {
       info: mockInfo,
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,7 +410,13 @@ export const migrateDatabase = async (
     }
 
     // Write the new database schema to file
-    await dumpSchemaToFile(client, schemaFile, throwOnChangedSchema, log)
+    await dumpSchemaToFile(
+      client,
+      schemaFile,
+      migrationTableName,
+      throwOnChangedSchema,
+      log,
+    )
   } finally {
     try {
       await releaseLock(client)
@@ -532,7 +538,13 @@ export const migrateV2ToV3 = async (
       scriptLines.push(commitTransactionCommand)
 
       // Write the new database schema to file
-      await dumpSchemaToFile(client, schemaFile, undefined, log)
+      await dumpSchemaToFile(
+        client,
+        schemaFile,
+        migrationTableName,
+        undefined,
+        log,
+      )
 
       // Write script to migration migration table to file.
       fs.writeFileSync(
@@ -632,6 +644,7 @@ export const overwriteDatabaseMd5 = async (
 export const dumpSchemaToFile = async (
   client: Client,
   schemaFile = SCHEMA_FILE,
+  migrationTableName = MIGRATION_TABLE_NAME,
   throwOnChangedSchema = false,
   log = { info: (message: unknown) => console.log(message) },
 ) => {
@@ -647,7 +660,7 @@ export const dumpSchemaToFile = async (
   const schemaDigestBefore = fs.existsSync(resolvedSchemaFile)
     ? await getDigestFromFile(resolvedSchemaFile)
     : ""
-  const schema = await dumpSchema(client)
+  const schema = await dumpSchema(client, migrationTableName)
   const schemaDigestAfter = getDigestFromString(schema)
   if (schemaDigestBefore === schemaDigestAfter) {
     log.info("Not updating schema file - no changes detected")


### PR DESCRIPTION
- Schema dump now lists table columns and enum members in lexicographic order.
- Should create consistent dump no matter the order in which migrations were applied.
- Outputs inserted migration rows, so that a database with the schema script applied would be caught-up.